### PR TITLE
Fix #718

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/PdfReader.java
@@ -3237,7 +3237,7 @@ public class PdfReader implements PdfViewerPreferences, Closeable {
           PdfObject v = ar.get(k);
           if (v.isIndirect()) {
             int num = ((PRIndirectReference) v).getNumber();
-            if (num >= xrefObj.size() || (!partial && xrefObj.get(num) == null)) {
+            if (num < 0 || num >= xrefObj.size() || (!partial && xrefObj.get(num) == null)) {
               ar.set(k, PdfNull.PDFNULL);
               continue;
             }


### PR DESCRIPTION
## Description of the new Feature/Bugfix
Prevent `ArrayIndexOutOfBoundsException` and use the same boundary check for arrays as already done for dictionaries.

Related Issue: #718

## Unit-Tests for the new Feature/Bugfix
- [ ] Unit-Tests added to reproduce the bug
- [ ] Unit-Tests added to the added feature

## Compatibilities Issues
This shouldn't change the compatibility for valid PDF files.

## Testing details
- nothing specific
